### PR TITLE
Modify issue template files to reference CMCC-CM.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: Bug report, CESM-wide or unknown component
-about: Report a problem with CESM for an unknown component; in many cases, one of the links below is more appropriate
+name: Bug report, CMCC-CM-wide or unknown component
+about: Report a problem with CMCC-CM for an unknown component; in many cases, one of the links below is more appropriate
 
 ---
 
@@ -10,7 +10,7 @@ about: Report a problem with CESM for an unknown component; in many cases, one o
 
 ### General bug information
 
-**CESM version you are using:** [Output of `git describe`]
+**CMCC-CM version you are using:** [Output of `git describe`]
 
 **Machine you are using:** [Fill this in]
 

--- a/.github/ISSUE_TEMPLATE/02_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/02_enhancement.md
@@ -1,6 +1,6 @@
 ---
-name: Enhancement request, CESM-wide or unknown component
-about: Suggest a CESM-wide enhancement; in many cases, one of the links below is more appropriate
+name: Enhancement request, CMCC-CM-wide or unknown component
+about: Suggest a CMCC-CM-wide enhancement; in many cases, one of the links below is more appropriate
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,35 +1,35 @@
 blank_issues_enabled: true
 contact_links:
-  - name: CIME issue
-    url: https://github.com/CMCC-Foundation/cime/issues/new/choose
-    about: Issue with CIME (scripting infrastructure, share code, etc.)
-  - name: CAM issue
-    url: https://github.com/CMCC-Foundation/CAM/issues/new/choose
-    about: Issue with CAM (Community Atmosphere Model)
-  - name: CTSM / CLM issue
-    url: https://github.com/CMCC-Foundation/CTSM/issues/new/choose
-    about: Issue with CTSM / CLM (Community Terrestrial Systems Model / Community Land Model) in CMCC-CM
-  - name: NEMO issue
-    url: https://github.com/CMCC-Foundation/NEMO-CESM/issues/new
-    about: Issue with NEMO in CMCC-CM
-  - name: CICE6 issue
-    url: https://github.com/CMCC-Foundation/CICE-CESM2/issues/new/choose
-    about: Issue with CICE6 in CMCC-CM
-  - name: MOSART issue
-    url: https://github.com/CMCC-Foundation/MOSART/issues/new/choose
-    about: Issue with MOSART in CESM (Model for Scale Adaptive River Transport)
-  - name: RTM issue
-    url: https://github.com/CMCC-Foundation/RTM/issues/new/choose
-    about: Issue with RTM (River Transport Model)
-  - name: CMEPS issue
-    url: https://github.com/CMCC-Foundation/CMEPS/issues/new/choose
-    about: Issue with CMEPS (NUOPC Community Mediator for Earth Prediction Systems)
-  - name: CDEPS issue
-    url: https://github.com/CMCC-Foundation/CDEPS/issues/new/choose
-    about: Issue with CDEPS (Community Data Models for Earth Prediction Systems)
   - name: ccs_config_cmcc issue
     url: https://github.com/CMCC-Foundation/ccw_config_cmcc/issues/new
-    about: Issue with configuration of CMCC supported grids, servers, and compilers.
+    about: Open new issue with configuration of CMCC supported grids, servers, and compilers.
+  - name: CIME issue
+    url: https://github.com/CMCC-Foundation/cime/issues/new/choose
+    about: Open new issue with CIME (scripting infrastructure) in CMCC-CM
+  - name: CMEPS issue
+    url: https://github.com/CMCC-Foundation/CMEPS/issues/new/choose
+    about: Open new issue with CMEPS (NUOPC Community Mediator for Earth Prediction Systems) in CMCC-CM
+  - name: CDEPS issue
+    url: https://github.com/CMCC-Foundation/CDEPS/issues/new/choose
+    about: Open new issue with CDEPS (Community Data Models for Earth Prediction Systems) in CMCC-CM
+  - name: CAM issue
+    url: https://github.com/CMCC-Foundation/CAM/issues/new/choose
+    about: Open new issue with CAM (Community Atmosphere Model) in CMCC-CM
+  - name: CICE6 issue
+    url: https://github.com/CMCC-Foundation/CICE-CESM2/issues/new/choose
+    about: Open new issue with CICE6 in CMCC-CM
+  - name: CTSM issue
+    url: https://github.com/CMCC-Foundation/CTSM/issues/new/choose
+    about: Open new issue with CTSM (Community Terrestrial Systems Model) in CMCC-CM
+  - name: MOSART issue
+    url: https://github.com/CMCC-Foundation/MOSART/issues/new/choose
+    about: Open new issue with MOSART (Model for Scale Adaptive River Transport) in CMCC-CM
+  - name: NEMO issue
+    url: https://github.com/CMCC-Foundation/NEMO-CESM/issues/new
+    about: Open new issue with NEMO in CMCC-CM
+  - name: RTM issue
+    url: https://github.com/CMCC-Foundation/RTM/issues/new/choose
+    about: Open new issue with RTM (River Transport Model) in CMCC-CM
   - name: share code issue
     url: https://github.com/CMCC-Foundation/CMCC_share/issues/new/choose
-    about: Issue with configuration of CMCC supported grids, servers, and compilers.
+    about: Open new issue with code shared across components in CMCC-CM

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: ccs_config_cmcc issue
-    url: https://github.com/CMCC-Foundation/ccw_config_cmcc/issues/new
+    url: https://github.com/CMCC-Foundation/ccs_config_cmcc/issues/new
     about: Open new issue with configuration of CMCC supported grids, servers, and compilers.
   - name: CIME issue
     url: https://github.com/CMCC-Foundation/cime/issues/new/choose

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,47 +1,35 @@
 blank_issues_enabled: true
 contact_links:
-  - name: CESM forums
-    url: https://bb.cgd.ucar.edu/cesm/
-    about: For support with model use, troubleshooting, etc., please use the CESM forums
   - name: CIME issue
-    url: https://github.com/ESMCI/cime/issues/new/choose
+    url: https://github.com/CMCC-Foundation/cime/issues/new/choose
     about: Issue with CIME (scripting infrastructure, share code, etc.)
   - name: CAM issue
-    url: https://bb.cgd.ucar.edu/cesm/forums/cam.133/
-    about: Issue with CAM (Community Atmosphere Model) - please report via forums
+    url: https://github.com/CMCC-Foundation/CAM/issues/new/choose
+    about: Issue with CAM (Community Atmosphere Model)
   - name: CTSM / CLM issue
-    url: https://github.com/ESCOMP/CTSM/issues/new/choose
-    about: Issue with CTSM / CLM (Community Terrestrial Systems Model / Community Land Model)
-  - name: POP issue
-    url: https://github.com/ESCOMP/POP2-CESM/issues/new/choose
-    about: Issue with POP in CESM (Parallel Ocean Program)
-  - name: MOM issue
-    url: https://github.com/ESCOMP/MOM_interface/issues/new/choose
-    about: Issue with MOM in CESM (Modular Ocean Model)
-  - name: CICE5 issue
-    url: https://github.com/ESCOMP/CESM_CICE5/issues/new/choose
-    about: Issue with CICE5
-  - name: CISM issue
-    url: https://github.com/ESCOMP/cism-wrapper/issues/new/choose
-    about: Issue with CISM (Community Ice Sheet Model)
+    url: https://github.com/CMCC-Foundation/CTSM/issues/new/choose
+    about: Issue with CTSM / CLM (Community Terrestrial Systems Model / Community Land Model) in CMCC-CM
+  - name: NEMO issue
+    url: https://github.com/CMCC-Foundation/NEMO-CESM/issues/new
+    about: Issue with NEMO in CMCC-CM
+  - name: CICE6 issue
+    url: https://github.com/CMCC-Foundation/CICE-CESM2/issues/new/choose
+    about: Issue with CICE6 in CMCC-CM
   - name: MOSART issue
-    url: https://github.com/ESCOMP/MOSART/issues/new/choose
+    url: https://github.com/CMCC-Foundation/MOSART/issues/new/choose
     about: Issue with MOSART in CESM (Model for Scale Adaptive River Transport)
   - name: RTM issue
-    url: https://github.com/ESCOMP/RTM/issues/new/choose
+    url: https://github.com/CMCC-Foundation/RTM/issues/new/choose
     about: Issue with RTM (River Transport Model)
-  - name: WW3 issue
-    url: https://github.com/ESCOMP/WW3-CESM/issues/new/choose
-    about: Issue with WW3 in CESM (WaveWatch III)
   - name: CMEPS issue
-    url: https://github.com/ESCOMP/CMEPS/issues/new/choose
+    url: https://github.com/CMCC-Foundation/CMEPS/issues/new/choose
     about: Issue with CMEPS (NUOPC Community Mediator for Earth Prediction Systems)
   - name: CDEPS issue
-    url: https://github.com/ESCOMP/CDEPS/issues/new/choose
+    url: https://github.com/CMCC-Foundation/CDEPS/issues/new/choose
     about: Issue with CDEPS (Community Data Models for Earth Prediction Systems)
-  - name: FMS issue
-    url: https://github.com/ESCOMP/FMS_interface/issues/new/choose
-    about: Issue with FMS in CESM
-  - name: CESM Experiments Database issue
-    url: https://github.com/NCAR/CESM_expdb2/issues/new/choose
-    about: Issue with the CESM Experiments Database
+  - name: ccs_config_cmcc issue
+    url: https://github.com/CMCC-Foundation/ccw_config_cmcc/issues/new
+    about: Issue with configuration of CMCC supported grids, servers, and compilers.
+  - name: share code issue
+    url: https://github.com/CMCC-Foundation/CMCC_share/issues/new/choose
+    about: Issue with configuration of CMCC supported grids, servers, and compilers.


### PR DESCRIPTION
### Description of changes
The new-issue choices will now reflect CMCC-Foundation forks and repositories, not ESCOMP or ESMCI repos.

### Specific notes
Modified issue template configuration to allow directly opening an issue from any forked or original CMCC-CM external.

Contributors other than yourself, if any: **NA**

Fixes: #2 

User interface changes?: Yes
Since this change only affects opening new issues for CMCC-CM, no backward compatibility is needed

Testing performed:
Since changes to `.github` files are only active on the default branch, I tested this change in my fork. 
Go to [my fork](https://github.com/gold2718/ESCOMPcesm) and click the green "New Issue" button 
or just go to https://github.com/gold2718/ESCOMPcesm/issues/new/choose

