### PR TITLE
Add B compsets for CMCC-CM

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -96,6 +96,52 @@
     <lname>HIST_CAM60%WCCM_CLM50%BGC-CROP_CICE_NEMO_MOSART_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>BCM1850sp</alias>
+    <lname>1850_CAM60%WCSC_CLM50%SP_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCM1850b</alias>
+    <lname>1850_CAM60%WCSC_CLM50%BGC_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCM1850bc</alias>
+    <lname>1850_CAM60%WCSC_CLM50%BGC-CROP_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCM2000sp</alias>
+    <lname>2000_CAM60%WCSC_CLM50%SP_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCM2000b</alias>
+    <lname>2000_CAM60%WCSC_CLM50%BGC_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCM2000bc</alias>
+    <lname>2000_CAM60%WCSC_CLM50%BGC-CROP_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCMHISTsp</alias>
+    <lname>HIST_CAM60%WCSC_CLM50%SP_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCMHISTb</alias>
+    <lname>HIST_CAM60%WCSC_CLM50%BGC_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>BCMHISTbc</alias>
+    <lname>HIST_CAM60%WCSC_CLM50%BGC-CROP_CICE_NEMO_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+
   <!-- Prognostic wave -->
 
 


### PR DESCRIPTION
### Description of changes

Added a list of B compsets to be used in the CMCC-CM simulations:

BCM1850sp -> CMCC-CM B case for fixed 1850 simulation with SP mode for land and WCSC mode for atmosphere
BCM1850b -> CMCC-CM B case for fixed 1850 simulation with BGC mode for land and WCSC mode for atmosphere
BCM1850bc -> CMCC-CM B case for fixed 1850 simulation with BGC-CROP mode for land and WCSC mode for atmosphere

BCM2000sp, BCM2000b, BCM2000bc -> as above but for fixed 2000 simulation
BCMHISTsp, BCMHISTb, BCMHISTbc -> as above but for historical simulation

These compsets will be updated on their river routing component as soon as HYDROS is implemented.

### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):

