### PR TITLE
Dev/ww3

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -94,7 +94,7 @@ local_path = components/rtm
 required = True
 
 [nemo]
-tag = nemo4.2.0_cm_02 
+tag = nemo4.2.0_cm_03 
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/NEMO-cime 
 local_path = components/nemo

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,14 +22,14 @@ externals = Externals.cfg
 required = True
 
 [cmeps]
-tag = cmeps0.13.81_cm3_v0
+tag = cmeps0.14.14_cm3_v0
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/CMEPS
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.67_cm3_v2
+tag = cdeps1.0.4_cm3_v0  
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/CDEPS
 local_path = components/cdeps
@@ -65,7 +65,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime6.0.83_cm3_v2
+tag = cime6.0.83_cm3_v3
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 [ccs_config]
 tag = ccs_config_cesm0.0.49_cm3_v3
 protocol = git
-repo_url = https://github.com/CMCC-Foundation/ccs_config_cmcc.git
+repo_url = https://github.com/CMCC-Foundation/ccs_config_cmcc
 local_path = ccs_config
 required = True
 
@@ -96,10 +96,18 @@ required = True
 [nemo]
 tag = nemo4.2.0_cm_02 
 protocol = git
-repo_url = https://github.com/CMCC-Foundation/NEMO-cime.git 
+repo_url = https://github.com/CMCC-Foundation/NEMO-cime 
 local_path = components/nemo
 externals = Externals.cfg
 required = True
+
+[ww3dev]
+tag = v0.0.5_cm3_01
+protocol = git
+repo_url = https://github.com/CMCC-Foundation/WW3_interface
+local_path = components/ww3dev
+externals = Externals.cfg
+required = True 
 
 [externals_description]
 schema_version = 1.0.01


### PR DESCRIPTION
### Description of changes

- Add ww3 as wave model component of CMCC-CM

- Update the version of cmeps and cdeps to account for cplhist as option for docn

- Update cime version to correct the use of quotes in the command arguments when writing replay.sh

- Update nemo version to correct a bug in buildnml

### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

#16 This PR introduce the ww3 component among the one used in CMCC-CM

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):

- Reference AMIP simulation
