### PR TITLE
Update Externals adding HYDROS and WW3DEV

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,12 +1,12 @@
 [ccs_config]
-tag = ccs_config_cesm0.0.49_cm3_v3
+tag = ccs_config_cesm0.0.49_cm3_v4
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/ccs_config_cmcc
 local_path = ccs_config
 required = True
 
 [cam]
-tag = cam6_3_085_cm3_v2
+tag = cam6_3_085_cm3_v3
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/CAM
 local_path = components/cam
@@ -65,7 +65,7 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime6.0.83_cm3_v3
+tag = cime6.0.83_cm3_v4
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/cime
 local_path = cime
@@ -84,13 +84,20 @@ tag = mosart1_0_47_cm3_v1
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/MOSART
 local_path = components/mosart
-required = True
+required = False
 
 [rtm]
 tag = rtm1_0_78_cm3_v0
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/RTM
 local_path = components/rtm
+required = False
+
+[hydros]
+tag = hydros_cm3_v00
+protocol = git
+repo_url = https://github.com/CMCC-Foundation/hydros-cm
+local_path = components/hydros
 required = True
 
 [nemo]
@@ -102,12 +109,12 @@ externals = Externals.cfg
 required = True
 
 [ww3dev]
-tag = v0.0.5_cm3_01
+tag = v0.0.5_cm3_02
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/WW3_interface
 local_path = components/ww3dev
 externals = Externals.cfg
-required = True 
+required = False 
 
 [externals_description]
 schema_version = 1.0.01


### PR DESCRIPTION
### Description of changes

- Add HYDROS as river routing model with relative changes in cime and ccs_config_cmcc
- Add WW3DEV as optional component with relative changes in cdeps and cmeps
- set RTM and MOSART as optional components
- Correct one bug in NEMO

### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):

-  one simulation with coupled model
