### PR TITLE
Update CAM repository to cam6_3_122_cm3_v3

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,7 +6,7 @@ local_path = ccs_config
 required = True
 
 [cam]
-tag = cam6_3_122_cm3_v1
+tag = cam6_3_122_cm3_v3
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/CAM
 local_path = components/cam


### PR DESCRIPTION
### Description of changes

Update the CAM tag in Externals.cfg to
cam6_3_122_cm3_v3
which uses the sparse checkout function of manage_externals to deal with COSP2 and CLUBB repositories. 

### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):

